### PR TITLE
B1corr

### DIFF
--- a/dosma/core/numpy_routines.py
+++ b/dosma/core/numpy_routines.py
@@ -161,7 +161,7 @@ def nan_to_num(x, copy=True, nan=0.0, posinf=None, neginf=None):
         return x._partial_clone(volume=vol)
 
 
-@implements(np.around, np.round, np.round_)
+@implements(np.around, np.round, np.round)
 def around(x, decimals=0, affine=False):
     """Round medical image pixel data (and optionally affine) to the given number of decimals.
 

--- a/dosma/models/model_loading_util.py
+++ b/dosma/models/model_loading_util.py
@@ -72,7 +72,7 @@ def model_from_config(cfg_file_or_dict, weights_dir=None, **kwargs) -> SegModel:
 
     if isinstance(cfg_file_or_dict, str):
         with open(cfg_file_or_dict, "r") as f:
-            cfg = yaml.load(f)
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
     else:
         cfg = cfg_file_or_dict
 

--- a/dosma/models/oaiunet2d.py
+++ b/dosma/models/oaiunet2d.py
@@ -79,6 +79,7 @@ class OAIUnet2D(KerasSegModel):
                 padding="same",
                 activation="relu",
                 kernel_initializer="he_normal",
+                name=f"conv2d_down_{depth_cnt}_1"  # Unique name for each layer
             )(pool)
             conv = Conv2D(
                 nfeatures[depth_cnt],
@@ -86,6 +87,7 @@ class OAIUnet2D(KerasSegModel):
                 padding="same",
                 activation="relu",
                 kernel_initializer="he_normal",
+                name=f"conv2d_down_{depth_cnt}_2"  # Unique name for each layer
             )(conv)
 
             conv = BN(axis=-1, momentum=0.95, epsilon=0.001)(conv)
@@ -134,6 +136,7 @@ class OAIUnet2D(KerasSegModel):
                 padding="same",
                 activation="relu",
                 kernel_initializer="he_normal",
+                name=f"conv2d_up_{depth_cnt}_1"  # Unique name for each layer
             )(up)
             conv = Conv2D(
                 nfeatures[depth_cnt],
@@ -141,6 +144,7 @@ class OAIUnet2D(KerasSegModel):
                 padding="same",
                 activation="relu",
                 kernel_initializer="he_normal",
+                name=f"conv2d_up_{depth_cnt}_2"  # Unique name for each layer
             )(conv)
 
             conv = BN(axis=-1, momentum=0.95, epsilon=0.001)(conv)

--- a/dosma/scan_sequences/mri/qdess.py
+++ b/dosma/scan_sequences/mri/qdess.py
@@ -214,7 +214,7 @@ class QDess(ScanSequence):
         alpha = float(ref_dicom.FlipAngle) if alpha is None else alpha
 
         if b1map:
-            alpha = np.multiply(self.b1map.volume, math.radians(alpha))
+            alpha = np.multiply(b1map.volume, math.radians(alpha))
             if np.allclose(np.sin(alpha / 2), 0):
                 warnings.warn("sin(flip angle) is close to 0 - t2 map may fail.")
         else:

--- a/setup.py
+++ b/setup.py
@@ -41,9 +41,9 @@ def get_resources():
     files = []
     # Elastix files
     for path in pathlib.Path("dosma/resources/elastix/params").rglob("*.*"):
-        files.append(str(path))
+        files.append(path.as_posix())
     for path in pathlib.Path("dosma/resources/templates").rglob("*.*"):
-        files.append(str(path))
+        files.append(path.as_posix())
     return [x.split("/", 1)[1] for x in files]
 
 


### PR DESCRIPTION
## Merging branch `b1corr` into `bone_seg` to handle B1 correction in `qdess.py`.

The main modification is adding possibility to pass a B1 map into qdess.py to correct T2 mapping for B1 inhomogeneities as proposed in Barbieri et al. Magn Reson Mater Phy 36 (2023) https://doi.org/10.1007/s10334-023-01094-y 

Key Changes: 
- modified  `generate_t2_map` function within `qdess.py` class so that a b1map (MedicalVolume object) can be passed as input in the function. Default initialization is `b1map: MedicalVolume = None`.
- in  `model_loading_util.py` added `Loader=yaml.FullLoader` in yaml.load( ) function as Loader is a required argument in newer versions. 
- in `oaiunet2d.py` made sure each `Conv2D` layer in ` __load_keras_model__()` has a unique name as this is a requirement in new versions of Keras. 


  